### PR TITLE
Adding New DataDog dependency to inconsistently formatted dependency map

### DIFF
--- a/versioncontrol/maps.go
+++ b/versioncontrol/maps.go
@@ -17,7 +17,7 @@ var GithubRepoURLForPackage = map[string]string{
 	"gopkg.in/resty.v1":               "https://github.com/go-resty/resty",
 	"gopkg.in/alecthomas/kingpin.v2":  "https://github.com/alecthomas/kingpin",
 	"honnef.co/go/tools":              "https://github.com/dominikh/go-tools",
-	"gopkg.in/DataDog/dd-trace-go.v1": "https://github.com/DataDog/dd-trace-go"
+	"gopkg.in/DataDog/dd-trace-go.v1": "https://github.com/DataDog/dd-trace-go",
 }
 
 var GerritRepoURLForPackage = map[string]string{

--- a/versioncontrol/maps.go
+++ b/versioncontrol/maps.go
@@ -1,22 +1,23 @@
 package versioncontrol
 
 var GithubRepoURLForPackage = map[string]string{
-	"go.opencensus.io":               "https://github.com/census-instrumentation/opencensus-go",
-	"google.golang.org/grpc":         "https://github.com/grpc/grpc-go",
-	"google.golang.org/genproto":     "https://github.com/googleapis/go-genproto",
-	"google.golang.org/appengine":    "https://github.com/golang/appengine",
-	"google.golang.org/api":          "https://api.github.com/repos/googleapis/google-api-go-client",
-	"cloud.google.com/go":            "https://api.github.com/repos/googleapis/google-cloud-go",
-	"gopkg.in/check.v1":              "https://github.com/go-check/check",
-	"gopkg.in/yaml.v2":               "https://github.com/go-yaml/yaml",
-	"gopkg.in/square/go-jose.v2":     "https://github.com/square/go-jose",
-	"go.etcd.io/bbolt":               "https://github.com/etcd-io/bbolt",
-	"go.uber.org/atomic":             "https://github.com/uber-go/atomic",
-	"go.uber.org/multierr":           "https://github.com/uber-go/multierr",
-	"go.uber.org/zap":                "https://github.com/uber-go/zap",
-	"gopkg.in/resty.v1":              "https://github.com/go-resty/resty",
-	"gopkg.in/alecthomas/kingpin.v2": "https://github.com/alecthomas/kingpin",
-	"honnef.co/go/tools":             "https://github.com/dominikh/go-tools",
+	"go.opencensus.io":                "https://github.com/census-instrumentation/opencensus-go",
+	"google.golang.org/grpc":          "https://github.com/grpc/grpc-go",
+	"google.golang.org/genproto":      "https://github.com/googleapis/go-genproto",
+	"google.golang.org/appengine":     "https://github.com/golang/appengine",
+	"google.golang.org/api":           "https://api.github.com/repos/googleapis/google-api-go-client",
+	"cloud.google.com/go":             "https://api.github.com/repos/googleapis/google-cloud-go",
+	"gopkg.in/check.v1":               "https://github.com/go-check/check",
+	"gopkg.in/yaml.v2":                "https://github.com/go-yaml/yaml",
+	"gopkg.in/square/go-jose.v2":      "https://github.com/square/go-jose",
+	"go.etcd.io/bbolt":                "https://github.com/etcd-io/bbolt",
+	"go.uber.org/atomic":              "https://github.com/uber-go/atomic",
+	"go.uber.org/multierr":            "https://github.com/uber-go/multierr",
+	"go.uber.org/zap":                 "https://github.com/uber-go/zap",
+	"gopkg.in/resty.v1":               "https://github.com/go-resty/resty",
+	"gopkg.in/alecthomas/kingpin.v2":  "https://github.com/alecthomas/kingpin",
+	"honnef.co/go/tools":              "https://github.com/dominikh/go-tools",
+	"gopkg.in/DataDog/dd-trace-go.v1": "https://github.com/DataDog/dd-trace-go"
 }
 
 var GerritRepoURLForPackage = map[string]string{


### PR DESCRIPTION
Recently, we had a pipeline failure on b5 because the dependency "gopkg.in/DataDog/dd-trace-go.v1" was not configured in the dep-report tool. This PR configures the DataDog dependency in the dep-report tool so that the pipeline will pass next time.