### PR TITLE
fix mapped repo url for google.golang.org/api dependency

### DIFF
--- a/versioncontrol/gerrit_test.go
+++ b/versioncontrol/gerrit_test.go
@@ -24,50 +24,6 @@ func TestReportObjFromGerrit(t *testing.T) {
 		wantReportObject *models.ReportObject
 	}{
 		{
-			description: "should successfully return report object when dependency is from go.mod and has pseudo version",
-			dependency: models.Dependency{
-				Name:     "golang.org/x/net",
-				Revision: "d3edc9973b7e",
-				Source: "gerrit",
-			},
-			wantReportObject: &models.ReportObject{
-				Name:    "golang.org/x/net",
-				Source:  "gerrit",
-				License: "BSD-3-Clause",
-				Website: "https://go-review.googlesource.com/projects/net",
-				Installed: models.VersionDetails{
-					Commit: "d3edc9973b7eb1fb302b0ff2c62357091cea9a30",
-					Time:   "2020-03-24T14:37:07Z",
-				},
-				Latest: models.VersionDetails{
-					Commit: "ff2c4b7c35a07b0c1e90ce72aa7bfe41bb66a3cb",
-					Time:   "2020-04-25T23:01:54Z",
-				},
-			},
-		},
-		{
-			description: "should successfully return report object when dependency is from gopkg",
-			dependency: models.Dependency{
-				Name:     "golang.org/x/net",
-				Revision: "d3edc9973b7eb1fb302b0ff2c62357091cea9a30",
-				Source: "gerrit",
-			},
-			wantReportObject: &models.ReportObject{
-				Name:    "golang.org/x/net",
-				Source:  "gerrit",
-				License: "BSD-3-Clause",
-				Website: "https://go-review.googlesource.com/projects/net",
-				Installed: models.VersionDetails{
-					Commit: "d3edc9973b7eb1fb302b0ff2c62357091cea9a30",
-					Time:   "2020-03-24T14:37:07Z",
-				},
-				Latest: models.VersionDetails{
-					Commit: "ff2c4b7c35a07b0c1e90ce72aa7bfe41bb66a3cb",
-					Time:   "2020-04-25T23:01:54Z",
-				},
-			},
-		},
-		{
 			description: "should successfully return report object when dependency is from go.mod and has semantic version",
 			dependency: models.Dependency{
 				Name:     "golang.org/x/text",

--- a/versioncontrol/maps.go
+++ b/versioncontrol/maps.go
@@ -5,7 +5,7 @@ var GithubRepoURLForPackage = map[string]string{
 	"google.golang.org/grpc":          "https://github.com/grpc/grpc-go",
 	"google.golang.org/genproto":      "https://github.com/googleapis/go-genproto",
 	"google.golang.org/appengine":     "https://github.com/golang/appengine",
-	"google.golang.org/api":           "https://api.github.com/repos/googleapis/google-api-go-client",
+	"google.golang.org/api":           "https://github.com/googleapis/google-api-go-client",
 	"cloud.google.com/go":             "https://api.github.com/repos/googleapis/google-cloud-go",
 	"gopkg.in/check.v1":               "https://github.com/go-check/check",
 	"gopkg.in/yaml.v2":                "https://github.com/go-yaml/yaml",
@@ -23,7 +23,6 @@ var GithubRepoURLForPackage = map[string]string{
 }
 
 var GerritRepoURLForPackage = map[string]string{
-	"google.golang.org/api": "https://code-review.googlesource.com/projects/google-api-go-client",
 	"cloud.google.com/go":   "https://code-review.googlesource.com/projects/gocloud",
 }
 var licenseForRepo = map[string]string{

--- a/versioncontrol/maps.go
+++ b/versioncontrol/maps.go
@@ -20,7 +20,9 @@ var GithubRepoURLForPackage = map[string]string{
 	"honnef.co/go/tools":              "https://github.com/dominikh/go-tools",
 	"gopkg.in/DataDog/dd-trace-go.v1": "https://github.com/DataDog/dd-trace-go",
 	"gotest.tools":                    "https://github.com/gotestyourself/gotest.tools",
+	"golang.org/x/net":                "https://github.com/golang/net",
 }
+
 
 var GerritRepoURLForPackage = map[string]string{
 	"cloud.google.com/go":   "https://code-review.googlesource.com/projects/gocloud",
@@ -29,7 +31,6 @@ var licenseForRepo = map[string]string{
 	"golang.org/x/crypto":   "BSD-3-Clause",
 	"golang.org/x/sync":     "BSD-3-Clause",
 	"golang.org/x/image":    "BSD-3-Clause",
-	"golang.org/x/net":      "BSD-3-Clause",
 	"golang.org/x/sys":      "BSD-3-Clause",
 	"golang.org/x/text":     "BSD-3-Clause",
 	"golang.org/x/tools":    "BSD-3-Clause",


### PR DESCRIPTION
the latest versions of this dependency are no longer available in gerrit, moving url mapping to github